### PR TITLE
Stop issuing git submodule command in build.rs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,9 @@ build:
   parallel: true
   verbosity: minimal
 
+before_build:
+  - git submodule update --init
+
 build_script:
   - cargo build --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ branches:
   only:
     - master
 
+before_script:
+  - git submodule update --init
+
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/build/build.rs
+++ b/build/build.rs
@@ -16,18 +16,6 @@ extern crate cmake;
 
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::Command;
-
-fn git_submodule_update<P: AsRef<Path>>(dir: P) {
-    let status = Command::new("git")
-        .args(&["submodule", "update", "--init"])
-        .current_dir(dir)
-        .status()
-        .expect("cannot execute git submodule");
-    if !status.success() {
-        panic!("git submodule update --init failed")
-    }
-}
 
 fn build_shaderc(shaderc_dir: &PathBuf) -> PathBuf {
         cmake::Config::new(shaderc_dir)
@@ -65,8 +53,6 @@ fn main() {
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let shaderc_dir = Path::new(&manifest_dir).join("build");
-
-    git_submodule_update(&manifest_dir);
 
     let mut lib_path = if target_env == "msvc" {
         build_shaderc_msvc(&shaderc_dir)


### PR DESCRIPTION
Cargo will automatically checkout submodules for crates published
on crates.io. Issuing git submodule in build.rs could be a problem
for projects using shaderc as a dependency.

Locally, we need to do git submodule update --init manually,
including the buildbots.