### PR TITLE
Fix paniq on shaderc_result_get_error_message returning invalid UTF-8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,19 +350,19 @@ fn propagate_panic<F, T>(f: F) -> T where F : FnOnce() -> T {
 
 /// Returns a valid UTF-8 string from a slice of bytes.
 ///
-/// A few shaderc functions have been observed to return invalid UTF-8 strings a
-/// s warning/error messages, and instead of paniqing and aborting execution this
-/// function can be used that will convert the valid parts of the byte stream to 
+/// A few shaderc functions have been observed to return invalid UTF-8 strings as
+/// warning/error messages, and instead of panicking and aborting execution this
+/// function can be used to convert the valid parts of the byte stream to 
 /// a UTF-8 string
 fn safe_str_from_utf8(bytes: &[u8]) -> String {
     match str::from_utf8(bytes) {
         Ok(str) => str.to_string(),
         Err(err) => {
             if err.valid_up_to() > 0 {
-                return format!("{} (followed by invalid UTF-8)", 
+                return format!("{} (followed by invalid UTF-8 characters)", 
                     safe_str_from_utf8(&bytes[.. err.valid_up_to()]));
             } else { 
-                return format!("invalid utf-8 stringe: {}", err);
+                return format!("invalid UTF-8 string: {}", err);
             }
         }
     }
@@ -402,7 +402,7 @@ impl Compiler {
                 3 => Err(Error::InternalError(reason)),
                 4 => Err(Error::NullResultObject(reason)),
                 5 => Err(Error::InvalidAssembly(reason)),
-               _ => panic!("unhandled shaderc error case"),
+                _ => panic!("unhandled shaderc error case"),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,27 @@ fn propagate_panic<F, T>(f: F) -> T where F : FnOnce() -> T {
     }
 }
 
+/// Returns a valid UTF-8 string from a slice of bytes.
+///
+/// A few shaderc functions have been observed to return invalid UTF-8 strings a
+/// s warning/error messages, and instead of paniqing and aborting execution this
+/// function can be used that will convert the valid parts of the byte stream to 
+/// a UTF-8 string
+fn safe_str_from_utf8(bytes: &[u8]) -> String {
+    match str::from_utf8(bytes) {
+        Ok(str) => str.to_string(),
+        Err(err) => {
+            if err.valid_up_to() > 0 {
+                return format!("{} (followed by invalid UTF-8)", 
+                    safe_str_from_utf8(&bytes[.. err.valid_up_to()]));
+            } else { 
+                return format!("invalid utf-8 stringe: {}", err);
+            }
+        }
+    }
+}
+
+
 impl Compiler {
     /// Returns an compiler object that can be used to compile SPIR-V modules.
     ///
@@ -373,7 +394,7 @@ impl Compiler {
             let reason = unsafe {
                 let p = ffi::shaderc_result_get_error_message(result);
                 let bytes = CStr::from_ptr(p).to_bytes();
-                str::from_utf8(bytes).ok().expect("invalid utf-8 string").to_string()
+                safe_str_from_utf8(bytes)
             };
             match status {
                 1 => Err(Error::InvalidStage(reason)),
@@ -381,7 +402,7 @@ impl Compiler {
                 3 => Err(Error::InternalError(reason)),
                 4 => Err(Error::NullResultObject(reason)),
                 5 => Err(Error::InvalidAssembly(reason)),
-                _ => panic!("unhandled shaderc error case"),
+               _ => panic!("unhandled shaderc error case"),
             }
         }
     }
@@ -972,7 +993,7 @@ impl CompilationArtifact {
         unsafe {
             let p = ffi::shaderc_result_get_error_message(self.raw);
             let bytes = CStr::from_ptr(p).to_bytes();
-            str::from_utf8(bytes).ok().expect("invalid utf-8 string").to_string()
+            safe_str_from_utf8(bytes)
         }
     }
 }


### PR DESCRIPTION
When compiling through a very large set of shaders I ran into panics from `shaderc_result_get_error_message` returning strings with invalid UTF-8 encoding which resulted in paniq from `.expect("invalid utf-8 string")`. 

I replaced that `expect` call with a new `safe_str_from_utf8` which will avoid paniq and use the UTF-8 error to convert at least the valid parts of the string and indicate that the rest of it is invalid. Which at least for warnings and error messages should be good to use, and better than paniq as that brings down the entire process