### PR TITLE
Force install directory to lib instead of lib64

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -23,6 +23,7 @@ fn build_shaderc(shaderc_dir: &PathBuf) -> PathBuf {
             .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
             .define("SPIRV_SKIP_EXECUTABLES", "ON")
             .define("SHADERC_SKIP_TESTS", "ON")
+            .define("CMAKE_INSTALL_LIBDIR", "lib")
             .build()
 }
 
@@ -39,6 +40,7 @@ fn build_shaderc_msvc(shaderc_dir: &PathBuf) -> PathBuf {
             .define("CMAKE_CXX_FLAGS", " /nologo /EHsc")
             .define("CMAKE_C_FLAGS_RELEASE", " /nologo /EHsc")
             .define("CMAKE_CXX_FLAGS_RELEASE", " /nologo /EHsc")
+            .define("CMAKE_INSTALL_LIBDIR", "lib")
             .build()
 }
 


### PR DESCRIPTION
When using shaderc on my computer, it compiled all the libraries into `target/debug/shaderc-.../out/lib64`, which made the linking step fail because it was expecting `lib` instead. I added a cmake parameter to force it to always output in `lib`.