### PR TITLE
Make sure to link to stdc++ when building Windows GNU

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,11 +20,12 @@ matrix:
     - channel: nightly
 
 install:
+  - echo %PATH%
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - if not %target% == %host% rustup target add %target%
-  - if defined mingw set PATH=%PATH%;C:\mingw-w64\%mingw%\mingw64\bin
+  - if defined mingw set PATH=%PATH:C:\Program Files\Git\usr\bin;=%;C:\mingw-w64\%mingw%\mingw64\bin
   - rustc -vV && cargo -vV && if defined mingw gcc --version
 
 build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,8 +5,14 @@ version: "{build}"
 environment:
   matrix:
     - channel: stable
+      host: x86_64-pc-windows-msvc
       target: x86_64-pc-windows-msvc
+    - channel: stable
+      host: x86_64-pc-windows-msvc
+      target: x86_64-pc-windows-gnu
+      mingw: x86_64-6.3.0-posix-seh-rt_v5-rev1
     - channel: nightly
+      host: x86_64-pc-windows-msvc
       target: x86_64-pc-windows-msvc
 
 matrix:
@@ -15,9 +21,11 @@ matrix:
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
-  - rustc -vV && cargo -vV
+  - if not %target% == %host% rustup target add %target%
+  - if defined mingw set PATH=%PATH%;C:\mingw-w64\%mingw%\bin
+  - rustc -vV && cargo -vV && if defined mingw gcc --version
 
 build:
   parallel: true
@@ -27,7 +35,7 @@ before_build:
   - git submodule update --init
 
 build_script:
-  - cargo build --verbose
+  - cargo build --verbose --target 
 
 test_script:
   - cargo test --verbose

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,15 +24,14 @@ install:
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - if not %target% == %host% rustup target add %target%
-  - if defined mingw set PATH=%PATH%;C:\mingw-w64\%mingw%\bin
-  - rustc -vV && cargo -vV && dir /b /s C:\mingw-w64\ && if defined mingw gcc --version
+  - if defined mingw set PATH=%PATH%;C:\mingw-w64\%mingw%\mingw64\bin
+  - rustc -vV && cargo -vV && if defined mingw gcc --version
 
 build:
   parallel: true
   verbosity: minimal
 
 before_build:
-  - exit 1
   - git submodule update --init
 
 build_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,6 @@ matrix:
     - channel: nightly
 
 install:
-  - echo %PATH%
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %host%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,17 +25,18 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - if not %target% == %host% rustup target add %target%
   - if defined mingw set PATH=%PATH%;C:\mingw-w64\%mingw%\bin
-  - rustc -vV && cargo -vV && if defined mingw gcc --version
+  - rustc -vV && cargo -vV && dir /b /s C:\mingw-w64\ && if defined mingw gcc --version
 
 build:
   parallel: true
   verbosity: minimal
 
 before_build:
+  - exit 1
   - git submodule update --init
 
 build_script:
-  - cargo build --verbose --target 
+  - cargo build --verbose --target %target%
 
 test_script:
-  - cargo test --verbose
+  - cargo test --verbose --target %target%

--- a/build/build.rs
+++ b/build/build.rs
@@ -30,20 +30,20 @@ fn build_shaderc(shaderc_dir: &PathBuf) -> PathBuf {
 
 fn build_shaderc_msvc(shaderc_dir: &PathBuf) -> PathBuf {
     cmake::Config::new(shaderc_dir)
-            .profile("Release")
-            .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
-            .define("SPIRV_SKIP_EXECUTABLES", "ON")
-            .define("SPIRV_WERROR", "OFF")
-            .define("SHADERC_SKIP_TESTS", "ON")
-            // cmake-rs tries to be clever on Windows by injecting several
-            // C/C++ flags, which causes problems. So I have to manually
-            // define CMAKE_*_FLAGS_* here to suppress that.
-            .define("CMAKE_C_FLAGS", " /nologo /EHsc")
-            .define("CMAKE_CXX_FLAGS", " /nologo /EHsc")
-            .define("CMAKE_C_FLAGS_RELEASE", " /nologo /EHsc")
-            .define("CMAKE_CXX_FLAGS_RELEASE", " /nologo /EHsc")
-            .define("CMAKE_INSTALL_LIBDIR", "lib")
-            .build()
+        .profile("Release")
+        .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
+        .define("SPIRV_SKIP_EXECUTABLES", "ON")
+        .define("SPIRV_WERROR", "OFF")
+        .define("SHADERC_SKIP_TESTS", "ON")
+        // cmake-rs tries to be clever on Windows by injecting several
+        // C/C++ flags, which causes problems. So I have to manually
+        // define CMAKE_*_FLAGS_* here to suppress that.
+        .define("CMAKE_C_FLAGS", " /nologo /EHsc")
+        .define("CMAKE_CXX_FLAGS", " /nologo /EHsc")
+        .define("CMAKE_C_FLAGS_RELEASE", " /nologo /EHsc")
+        .define("CMAKE_CXX_FLAGS_RELEASE", " /nologo /EHsc")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
+        .build()
 }
 
 fn main() {

--- a/build/build.rs
+++ b/build/build.rs
@@ -70,17 +70,8 @@ fn main() {
     println!("cargo:rustc-link-lib=static=shaderc_combined");
 
     match (target_os.as_str(), target_env.as_str()) {
-        ("linux", _) => println!("cargo:rustc-link-lib=dylib=stdc++"),
+        ("linux", _) | ("windows", "gnu") => println!("cargo:rustc-link-lib=dylib=stdc++"),
         ("macos", _) => println!("cargo:rustc-link-lib=dylib=c++"),
-        ("windows", "gnu") => {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
-
-            // linking to these are needed for doctests as proc-macros; see:
-            // https://github.com/rust-lang/rust/issues/41607
-            println!("cargo:rustc-link-lib=dylib=gcc_eh");
-            println!("cargo:rustc-link-lib=dylib=pthread");
-            println!("cargo:rustc-link-lib=dylib=msvcrt");
-        }
         _ => {}
     }
 }


### PR DESCRIPTION
Must link to stdc++ when building on Windows with a GNU toolchain.

Some discussion about this change here google/shaderc-rs#26