### PR TITLE
Document setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,54 @@ let text_result = compiler.compile_into_spirv_assembly(
 assert!(text_result.as_text().starts_with("; SPIR-V\n"));
 ```
 
+Setup
+-----
+
+To build the shaderc-rs crate the following tools must be installed and available on `PATH`:
+- [CMake](https://cmake.org/)
+- [Python](https://www.python.org/) (works with both Python 2.x and 3.x)
+- a C++ compiler
+
+These requirements can be either installed with your favourite package manager or with installers
+from the projects' websites. Below are some example ways to get setup.
+
+### windows-msvc Specific Setup
+
+1. `rustup default stable-x86_64-pc-windows-msvc`
+2. Install [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017). If you have already been using this toolchain then its probably already installed.
+3.  Install [msys2](http://www.msys2.org/), following ALL of the instructions.
+4.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-python3`
+5.  Add the msys2 mingw64 binary path to the PATH environment variable.
+
+### Windows-gnu Specific Setup
+
+windows-gnu toolchain is not supported but you can instead cross-compile to windows-gnu from windows-msvc
+
+Steps 1 and 2 are to workaround https://github.com/rust-lang/rust/issues/49078 by using the same mingw that rust uses.
+
+1.  Download and extract https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
+2.  Add the absolute path to mingw64\bin to your PATH environment variable. (This path needs to be before the msys2 path)
+3.  Run the command: `rustup default stable-x86_64-pc-windows-msvc`
+4.  Run the command: `rustup target install x86_64-pc-windows-gnu`
+5.  Install [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017). If you have already been using this toolchain then its probably already installed.
+6.  Install [msys2](http://www.msys2.org/), following ALL of the instructions.
+7.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw64/mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-python3`
+8.  Add the msys2 mingw64 binary path to the PATH environment variable.
+9.  Any cargo command that builds the project needs to include `--target x86_64-pc-windows-gnu` e.g. to run: `cargo run --target x86_64-pc-windows-gnu`
+
+### Linux Specific Setup
+
+Use your package manager to install the required dev-tools and vulkan drivers
+
+For example on ubuntu:
+```
+sudo apt-get install build-essential git python cmake
+```
+
+### macOS Specific Setup
+
+TODO: macOS works but someone needs to document an easy way to setup the dependencies.
+
 Contributions
 -------------
 


### PR DESCRIPTION
This PR resolves most of https://github.com/google/shaderc-rs/issues/26 (still need docs for macOS which I cant help with)

There are a few variations possible here:
*   The whole thing could go in a separate `compiling.md` document.
*   it could use chocolatey instead of msys2 for the windows-msvc setup (I opted to keep it the same as windows-gnu as I think that's easier to manage)

It's mostly the same as the new documentation I added to https://github.com/vulkano-rs/vulkano/