### PR TITLE
Fix python installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Setup
 
 To build the shaderc-rs crate, the following tools must be installed and available on `PATH`:
 - [CMake](https://cmake.org/)
-- [Python](https://www.python.org/) (works with both Python 2.x and 3.x)
+- [Python](https://www.python.org/) (works with both Python 2.x and 3.x, on windows the executable must be named `python.exe`)
 - a C++11 compiler
 
 These requirements can be either installed with your favourite package manager or with installers
@@ -93,7 +93,7 @@ from the projects' websites. Below are some example ways to get setup.
 1.  `rustup default stable-x86_64-pc-windows-msvc`
 2.  Install [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017). If you have already been using this toolchain then its probably already installed.
 3.  Install [msys2](http://www.msys2.org/), following ALL of the instructions.
-4.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-python3`
+4.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-python2`
 5.  Add the msys2 mingw64 binary path to the PATH environment variable.
 
 ### windows-gnu Example Setup
@@ -108,7 +108,7 @@ Steps 1 and 2 are to workaround https://github.com/rust-lang/rust/issues/49078 b
 4.  Run the command: `rustup target install x86_64-pc-windows-gnu`
 5.  Install [Build Tools for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017). If you have already been using this toolchain then its probably already installed.
 6.  Install [msys2](http://www.msys2.org/), following ALL of the instructions.
-7.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-python3`
+7.  Then in the msys2 terminal run: `pacman --noconfirm -Syu mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-python2`
 8.  Add the msys2 mingw64 binary path to the PATH environment variable.
 9.  Any cargo command that builds the project needs to include `--target x86_64-pc-windows-gnu` e.g. to run: `cargo run --target x86_64-pc-windows-gnu`
 


### PR DESCRIPTION
Turns out it cant handle the executable named python3.exe, a symlink would solve it, but the easiest solution is to just install python2 instead.
I think the only reason it worked for me before is because I had python2 installed and didn't realize it was being used instead.