### PR TITLE
Proposal: Require ninja when building with MSVC

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -33,7 +33,7 @@ fn build_shaderc(shaderc_dir: &PathBuf, use_ninja: bool) -> PathBuf {
     config.build()
 }
 
-fn build_shaderc_msvc(shaderc_dir: &PathBuf, use_ninja: bool) -> PathBuf {
+fn build_shaderc_msvc(shaderc_dir: &PathBuf) -> PathBuf {
     let mut config = cmake::Config::new(shaderc_dir);
     config.profile("Release")
         .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
@@ -47,10 +47,8 @@ fn build_shaderc_msvc(shaderc_dir: &PathBuf, use_ninja: bool) -> PathBuf {
         .define("CMAKE_CXX_FLAGS", " /nologo /EHsc")
         .define("CMAKE_C_FLAGS_RELEASE", " /nologo /EHsc")
         .define("CMAKE_CXX_FLAGS_RELEASE", " /nologo /EHsc")
-        .define("CMAKE_INSTALL_LIBDIR", "lib");
-    if use_ninja {
-        config.generator("Ninja");
-    }
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
+        .generator("Ninja");
     config.build()
 }
 
@@ -70,8 +68,6 @@ fn main() {
     finder.must_have("git");
     finder.must_have("python");
 
-    let has_ninja = finder.maybe_have("ninja").is_some();
-
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
@@ -79,8 +75,10 @@ fn main() {
     let shaderc_dir = Path::new(&manifest_dir).join("build");
 
     let mut lib_path = if target_env == "msvc" {
-        build_shaderc_msvc(&shaderc_dir, has_ninja)
+        finder.must_have("ninja");
+        build_shaderc_msvc(&shaderc_dir)
     } else {
+        let has_ninja = finder.maybe_have("ninja").is_some();
         build_shaderc(&shaderc_dir, has_ninja)
     };
 


### PR DESCRIPTION
This PR is a proposal to make ninja a hard requirement when building with MSVC. It remains optional in all other cases.

The motivation for this change is that, if building with MSVC but without ninja, shaderc builds with msbuild, which often causes the build to fail due to the excessively long path names generated by the msbuild project generator. This is especially true when shaderc is built as a dependency of another project, since in that case it will build in a nested subdirectory.

The best solution to this problem is to build with ninja instead, but this solution is not obvious especially for users of downstream projects, who are unlikely to have read the shaderc README, or think of reading it as their first action to try to solve the problem.

With this change, if ninja is not available and the user is compiling with MSVC, the build will fail with:

> couldn't find required command: "ninja"'

This at least points the user in the right direction, at the IMHO very minor cost of requiring ninja in some cases where it is not absolutely necessary.

By comparison, if the build fails due to long path names (without this change), the relevant error message looks like:

> C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\VC\VCTargets\Microsoft.CppBuild.targets(321,5): error MSB3491: Could not write lines to file "x64\Release\spirv-tools-spv-amd-shader-explicit-vertex-parameter\spirv-to.1662915F.tlog\spirv-tools-spv-amd-shader-explicit-vertex-parameter.lastbuildstate". The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters. [C:\Users\travis\build\djcsdy\gfx\target\debug\build\shaderc-65c2fb29275ff843\out\build\spirv-tools\source\spirv-tools-spv-amd-shader-explicit-vertex-parameter.vcxproj]

Although this a very well-written error message and thoroughly describes the underlying problem, it doesn’t do anything to point the user in the right direction and can lead to hours of confused searching and experimentation. I know this because it happened to me :-).

If you like this change and want to merge it then I will also update the documentation to reflect this change.