### PR TITLE
Add Windows MSVC support for the SHADERC_LIB_DIR option

### DIFF
--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 
 static COMBINED_LIB: &str = "shaderc_combined";
 static COMBINED_LIB_FILE: &str = "libshaderc_combined.a";
+static COMBINED_LIB_FILE_MSVC: &str = "shaderc_combined.lib";
 static SPIRV_LIB_FILE: &str = "libSPIRV.a";
 
 fn build_shaderc(shaderc_dir: &PathBuf, use_ninja: bool) -> PathBuf {
@@ -139,7 +140,11 @@ fn main() {
 
     if let Some(search_dir) = search_dir {
         let search_dir_str = search_dir.to_string_lossy();
-        let combined_lib_path = search_dir.join(COMBINED_LIB_FILE);
+        let combined_lib_name = match target_env.as_str() {
+            "msvc" => COMBINED_LIB_FILE_MSVC,
+            _ => COMBINED_LIB_FILE,
+        };
+        let combined_lib_path = search_dir.join(combined_lib_name.clone());
         let dylib_name = format!("{}shaderc{}", consts::DLL_PREFIX, consts::DLL_SUFFIX);
         let dylib_path = search_dir.join(dylib_name.clone());
 
@@ -184,6 +189,16 @@ fn main() {
                     println!("cargo:rustc-link-search=native={}", lib_dir);
                     println!("cargo:rustc-link-lib=static={}", lib_name);
                     println!("cargo:rustc-link-lib=dylib=stdc++");
+                    return;
+                }
+                ("windows", "msvc") => {
+                    println!(
+                        "cargo:warning=Windows msvc static builds \
+                         experimental"
+                    );
+                    println!("cargo:rustc-link-search=native={}", lib_dir);
+                    println!("cargo:rustc-link-lib=static={}", lib_name);
+                    // It seems msvc automatically links stdc++
                     return;
                 }
                 ("macos", _) => {


### PR DESCRIPTION
Currently the SHADERC_LIB_DIR only works for windows-gnu (and unix systems), but [google/shaderc](https://github.com/google/shaderc) also provides the prebuilt library for MSVC on their [downloads page](https://github.com/google/shaderc/blob/master/downloads.md).

NOTE: this is a prerequisite for fixing Issue #39 (but also useful on it's own)

TESTING: it works on my machine ;)
(I used it transitively through [vulkano-shaders](https://github.com/vulkano-rs/vulkano/tree/master/vulkano-shaders) in a personal project)