### PR TITLE
Add support for static MSVC CRT on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,10 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: stable
       host: x86_64-pc-windows-msvc
+      target: x86_64-pc-windows-msvc
+      RUSTFLAGS: "-C target-feature=+crt-static"
+    - channel: stable
+      host: x86_64-pc-windows-msvc
       target: x86_64-pc-windows-gnu
       mingw: x86_64-6.3.0-posix-seh-rt_v5-rev1
     - channel: nightly


### PR DESCRIPTION
We wanted to use shaderc with full static linking of the MSVC CRT on Windows, so added detection in `build.rs` if  `crt-static` is used and if so enable it instead of the default dynamic static linking.

This works both for enabling the static C runtime in a program with `.cargo/config` like this:

```toml
[target.x86_64-pc-windows-msvc]
rustflags = ["-C", "target-feature=+crt-static"]
```

And enabling it on the command-line with the `RUSTFLAGS` env var (which cargo picks up): 

`RUSTFLAGS='-C target-feature=+crt-static' cargo test`

