### PR TITLE
Set target spirv

### DIFF
--- a/shaderc-rs/src/lib.rs
+++ b/shaderc-rs/src/lib.rs
@@ -169,6 +169,23 @@ pub enum TargetEnv {
     OpenGLCompat,
 }
 
+/// The known versions of SPIR-V.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpirvVersion {
+    // Use the values used for word 1 of a SPIR-V binary:
+    // - bits 24 to 31: zero
+    // - bits 16 to 23: major version number
+    // - bits 8 to 15: minor version number
+    // - bits 0 to 7: zero
+    V1_0 = 0x0001_0000,
+    V1_1 = 0x0001_0100,
+    V1_2 = 0x0001_0200,
+    V1_3 = 0x0001_0300,
+    V1_4 = 0x0001_0400,
+    V1_5 = 0x0001_0500,
+}
+
 /// Source language.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -677,6 +694,15 @@ impl<'a> CompileOptions<'a> {
     /// of the target environment. "0" is the only supported value right now.
     pub fn set_target_env(&mut self, env: TargetEnv, version: u32) {
         unsafe { scs::shaderc_compile_options_set_target_env(self.raw, env as i32, version) }
+    }
+
+    /// Sets the target SPIR-V version. The generated module will use this version
+    /// of SPIR-V. Each target environment determines what versions of SPIR-V
+    /// it can consume. Defaults to the highest version of SPIR-V 1.0 which is
+    /// required to be supported by the target environment.  E.g. Default to SPIR-V
+    /// 1.0 for Vulkan 1.0 and SPIR-V 1.3 for Vulkan 1.1.
+    pub fn set_target_spirv(&mut self, version: SpirvVersion) {
+        unsafe { scs::shaderc_compile_options_set_target_spirv(self.raw, version as i32) }
     }
 
     /// Sets the source language.

--- a/shaderc-rs/src/lib.rs
+++ b/shaderc-rs/src/lib.rs
@@ -169,6 +169,25 @@ pub enum TargetEnv {
     OpenGLCompat,
 }
 
+/// Target environment version.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EnvVersion {
+    // For Vulkan, use Vulkan's mapping of version numbers to integers.
+    // See vulkan.h
+    Vulkan1_0 = (1 << 22),
+    Vulkan1_1 = ((1 << 22) | (1 << 12)),
+    Vulkan1_2 = ((1 << 22) | (2 << 12)),
+    // For OpenGL, use the number from #version in shaders.
+    // TODO(dneto): Currently no difference between OpenGL 4.5 and 4.6.
+    // See glslang/Standalone/Standalone.cpp
+    // TODO(dneto): Glslang doesn't accept a OpenGL client version of 460.
+    OpenGL4_5 = 450,
+    // Currently WebGPU doesn't have versioning, since it isn't finalized. This
+    // will have to be updated once the spec is finished.
+    WebGPU,
+}
+
 /// The known versions of SPIR-V.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -691,7 +710,9 @@ impl<'a> CompileOptions<'a> {
     /// The default is Vulkan if not set.
     ///
     /// `version` will be used for distinguishing between different versions
-    /// of the target environment. "0" is the only supported value right now.
+    /// of the target environment.
+    /// Note that EnvVersion must be cast to u32 when calling set_target_env.
+    /// For example: `options.set_target_env(shaderc::TargetEnv::Vulkan, shaderc::EnvVersion::Vulkan1_1 as u32);`
     pub fn set_target_env(&mut self, env: TargetEnv, version: u32) {
         unsafe { scs::shaderc_compile_options_set_target_env(self.raw, env as i32, version) }
     }

--- a/shaderc-sys/src/lib.rs
+++ b/shaderc-sys/src/lib.rs
@@ -153,6 +153,10 @@ extern "C" {
         env: i32,
         version: u32,
     );
+    pub fn shaderc_compile_options_set_target_spirv(
+        options: *mut ShadercCompileOptions,
+        version: i32,
+    );
     pub fn shaderc_compile_options_set_limit(
         options: *mut ShadercCompileOptions,
         limit: i32,
@@ -196,9 +200,7 @@ extern "C" {
     );
 
     pub fn shaderc_result_release(result: *mut ShadercCompilationResult);
-    pub fn shaderc_result_get_compilation_status(
-        result: *const ShadercCompilationResult,
-    ) -> i32;
+    pub fn shaderc_result_get_compilation_status(result: *const ShadercCompilationResult) -> i32;
     pub fn shaderc_result_get_num_errors(result: *const ShadercCompilationResult) -> size_t;
     pub fn shaderc_result_get_num_warnings(result: *const ShadercCompilationResult) -> size_t;
     pub fn shaderc_result_get_error_message(


### PR DESCRIPTION
Add set_target_spirv compile option and EnvVersion enum to call set_target_env with.

Note that EnvVersion must be cast to u32 when calling set_target_env.
For example: `options.set_target_env(shaderc::TargetEnv::Vulkan, shaderc::EnvVersion::Vulkan1_1 as u32);`
This was chosen to avoid breaking the API.
