### PR TITLE
Add set_hlsl_functionality1, set_invert_y, set_nan_clamp bindings

### DIFF
--- a/shaderc-rs/src/lib.rs
+++ b/shaderc-rs/src/lib.rs
@@ -1004,6 +1004,30 @@ impl<'a> CompileOptions<'a> {
         }
     }
 
+    /// Sets whether the compiler should enable extension SPV_GOOGLE_hlsl_functionality1.
+    pub set_hlsl_functionality1(&mut self, enable: bool) {
+        unsafe {
+            scs::shaderc_compile_options_set_hlsl_functionality1(self.raw, enable);
+        }
+    }
+
+    /// Sets whether the compiler should invert position.Y output in vertex shader.
+    pub set_invert_y(&mut self, enable: bool) {
+        unsafe {
+            scs::shaderc_compile_options_set_invert_y(self.raw, enable);
+        }
+    }
+
+    /// Sets whether the compiler generates code for max and min builtins which,
+    /// if given a NaN operand, will return the other operand. Similarly, the clamp
+    /// builtin will favour the non-NaN operands, as if clamp were implemented
+    /// as a composition of max and min.
+    pub set_nan_clamp(&mut self, enable: bool) {
+        unsafe {
+            scs::shaderc_compile_options_set_nan_clamp(self.raw, enable);
+        }
+    }
+
     /// Adds a predefined macro to the compilation options.
     ///
     /// This has the same effect as passing `-Dname=value` to the command-line

--- a/shaderc-rs/src/lib.rs
+++ b/shaderc-rs/src/lib.rs
@@ -1005,14 +1005,14 @@ impl<'a> CompileOptions<'a> {
     }
 
     /// Sets whether the compiler should enable extension SPV_GOOGLE_hlsl_functionality1.
-    pub set_hlsl_functionality1(&mut self, enable: bool) {
+    pub fn set_hlsl_functionality1(&mut self, enable: bool) {
         unsafe {
             scs::shaderc_compile_options_set_hlsl_functionality1(self.raw, enable);
         }
     }
 
     /// Sets whether the compiler should invert position.Y output in vertex shader.
-    pub set_invert_y(&mut self, enable: bool) {
+    pub fn set_invert_y(&mut self, enable: bool) {
         unsafe {
             scs::shaderc_compile_options_set_invert_y(self.raw, enable);
         }
@@ -1022,7 +1022,7 @@ impl<'a> CompileOptions<'a> {
     /// if given a NaN operand, will return the other operand. Similarly, the clamp
     /// builtin will favour the non-NaN operands, as if clamp were implemented
     /// as a composition of max and min.
-    pub set_nan_clamp(&mut self, enable: bool) {
+    pub fn set_nan_clamp(&mut self, enable: bool) {
         unsafe {
             scs::shaderc_compile_options_set_nan_clamp(self.raw, enable);
         }

--- a/shaderc-sys/src/lib.rs
+++ b/shaderc-sys/src/lib.rs
@@ -198,6 +198,18 @@ extern "C" {
         set: *const c_char,
         binding: *const c_char,
     );
+    pub fn shaderc_compile_options_set_hlsl_functionality1(
+        options: *mut ShadercCompileOptions,
+        enable: bool
+    );
+    pub fn shaderc_compile_options_set_invert_y(
+        options: *mut ShadercCompileOptions,
+        enable: bool
+    );
+    pub fn shaderc_compile_options_set_nan_clamp(
+        options: *mut ShadercCompileOptions,
+        enable: bool
+    );
 
     pub fn shaderc_result_release(result: *mut ShadercCompilationResult);
     pub fn shaderc_result_get_compilation_status(result: *const ShadercCompilationResult) -> i32;


### PR DESCRIPTION
These functions are present in the original shaderc library, but not in shaderc-rs. The doc comments are basically just copied from the original library.