### PR TITLE
Initial iOS support

### DIFF
--- a/.travis-ios.sh
+++ b/.travis-ios.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+if [ `uname` = Darwin ]
+then
+    rustup target add x86_64-apple-ios aarch64-apple-ios;
+    cargo build --target x86_64-apple-ios
+    cargo build --target aarch64-apple-ios
+    RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1)
+    export SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 $RUNTIME_ID)
+    xcrun simctl boot $SIM_ID
+    cargo install cargo-dinghy
+    cargo dinghy test --target x86_64-apple-ios
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 os:
   - linux
   - osx
+  - osx_image: xcode12
 rust:
   - stable
   - nightly
@@ -19,10 +20,12 @@ branches:
 
 before_script:
   - git submodule update --init
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rustup target add x86_64-apple-ios aarch64-apple-ios; fi
 
 script:
   - travis_wait cargo build --verbose
   - cargo test --verbose
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cargo build --target x86_64-apple-ios && cargo build --target aarch64-apple-ios; fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ branches:
 
 before_script:
   - git submodule update --init
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rustup target add x86_64-apple-ios aarch64-apple-ios; fi
 
 script:
   - travis_wait cargo build --verbose
   - cargo test --verbose
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cargo build --target x86_64-apple-ios && cargo build --target aarch64-apple-ios; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ./.travis-ios.sh; fi
 
 notifications:
   email:


### PR DESCRIPTION
Pretty consistently, people [open up the generated `CMakeCache.txt` and change `CMAKE_OSX_SYSROOT` to point to the iOS SDK path](https://github.com/google/shaderc-rs/issues/40#issuecomment-538662203). This PR makes it so they don't have to do it manually. I've also gone ahead and added the iphonesimulator and the phone target to travis so there's a small amount of CI. I'm open to adding [`cargo-dinghy`](https://github.com/sonos/dinghy/blob/02e315de0886e48cc7c105a4cecfb4196291087e/.travis.sh#L59-L85) to effectively run `cargo test` for the iOS simulator if we'd like. I just wanted to keep the PR small.

Let me know if there's any changes you'd like.