### PR TITLE
Initial Android support

### DIFF
--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -218,7 +218,9 @@ fn main() {
             } else if dylib_path.exists() {
                 Some((SHADERC_SHARED_LIB, "dylib"))
             } else {
-                None
+                // TODO: Make it check is there necessary libs
+                Some(("", "static"))
+                // None
             }
         } {
             match (target_os.as_str(), target_env.as_str()) {
@@ -288,7 +290,16 @@ fn main() {
                 ("android", _) => {
                     println!("cargo:warning=Android static builds experimental");
                     println!("cargo:rustc-link-search=native={}", search_dir_str);
-                    println!("cargo:rustc-link-lib={}={}", kind, lib_name);
+                    println!("cargo:rustc-link-lib=dylib=c++_shared");
+                    println!("cargo:rustc-link-lib={}=glslang", kind);
+                    println!("cargo:rustc-link-lib={}=HLSL", kind);
+                    println!("cargo:rustc-link-lib={}=OGLCompiler", kind);
+                    println!("cargo:rustc-link-lib={}=OSDependent", kind);
+                    println!("cargo:rustc-link-lib={}=shaderc_util", kind);
+                    println!("cargo:rustc-link-lib={}=shaderc", kind);
+                    println!("cargo:rustc-link-lib={}=SPIRV-Tools-opt", kind);
+                    println!("cargo:rustc-link-lib={}=SPIRV-Tools", kind);
+                    println!("cargo:rustc-link-lib={}=SPIRV", kind);
                     return;
                 }
                 (_, _) => {

--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -64,7 +64,7 @@ fn build_shaderc(shaderc_dir: &PathBuf, use_ninja: bool, target_os: String) -> P
         config.generator("Ninja");
     }
 
-    if target_os == "ios" {
+    if target_os == "ios" || target_os == "android" {
         if let Some(path) = sdk_path() {
             config.define("CMAKE_OSX_SYSROOT", path);
         }
@@ -283,6 +283,12 @@ fn main() {
                     println!("cargo:rustc-link-search=native={}", search_dir_str);
                     println!("cargo:rustc-link-lib={}={}", kind, lib_name);
                     println!("cargo:rustc-link-lib=dylib=c++");
+                    return;
+                }
+                ("android", _) => {
+                    println!("cargo:warning=Android static builds experimental");
+                    println!("cargo:rustc-link-search=native={}", search_dir_str);
+                    println!("cargo:rustc-link-lib={}={}", kind, lib_name);
                     return;
                 }
                 (_, _) => {


### PR DESCRIPTION
Closes #87 

I was able to run `shaderc-rs` on the Android app with dynamically linked shaderc that was built with the `ndk-build` tool inside `build/shaderc/android_test` folder with the following command:
```
ndk-build APP_BUILD_SCRIPT=Android.mk SPVTOOLS_LOCAL_PATH=../third_party/spirv-tools SPVHEADERS_LOCAL_PATH=../third_party/spirv-headers APP_STL:=c++_shared APP_ABI=all -j
```

Then I provide the path to the libs folder as `SHADERC_LIB_DIR`. I'm sure that this is not a good way to make it work but still - it works and I want to hear any feedback on how to make it right.

Also, there's still not possible to build it with the `CARGO_FEATURE_BUILD_FROM_SOURCE` and without PITA while building it with `ndk-build` by yourself. Should I add `ndk-build` to `build.rs` or there some way to do it with `ninja`?