### PR TITLE
fixing aarch64 simulator detection

### DIFF
--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -29,9 +29,9 @@ fn get_apple_sdk_path() -> Option<PathBuf> {
     use std::process::Command;
 
     // tvOS (and the simulator) could be added here in the future.
-    let sdk = if target == "x86_64-apple-ios" 
-        || target == "i386-apple-ios" 
-        || target == "aarch64-apple-ios-sim" 
+    let sdk = if target == "x86_64-apple-ios"
+        || target == "i386-apple-ios"
+        || target == "aarch64-apple-ios-sim"
     {
         "iphonesimulator"
     } else if target == "aarch64-apple-ios"

--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -29,7 +29,10 @@ fn get_apple_sdk_path() -> Option<PathBuf> {
     use std::process::Command;
 
     // tvOS (and the simulator) could be added here in the future.
-    let sdk = if target == "x86_64-apple-ios" || target == "i386-apple-ios" {
+    let sdk = if target == "x86_64-apple-ios" 
+        || target == "i386-apple-ios" 
+        || target == "aarch64-apple-ios-sim" 
+    {
         "iphonesimulator"
     } else if target == "aarch64-apple-ios"
         || target == "armv7-apple-ios"


### PR DESCRIPTION
Fixing detection of iOS simulator on arm64 (Xcode on M1 Macos).
Rust's nightly has a aarch64-apple-ios-sim target, which doesn't get assigned to correct sdk without this fix, 