### PR TITLE
fixes bug #108, makes cmd_finder.rs not to follow symbolic link to te…

### DIFF
--- a/shaderc-sys/build/cmd_finder.rs
+++ b/shaderc-sys/build/cmd_finder.rs
@@ -32,7 +32,12 @@ impl CommandFinder {
                     let target = path.join(&cmd);
                     let mut cmd_alt = cmd.clone();
                     cmd_alt.push(".exe");
+                    let mut symlink_is_file = false;
+                    if let Ok(metadata) = target.with_extension("exe").symlink_metadata() {
+                        symlink_is_file = metadata.is_file()
+                    }
                     if target.is_file() || // some/path/git
+                symlink_is_file ||
                 target.with_extension("exe").exists() || // some/path/git.exe
                 target.join(&cmd_alt).exists()
                     {


### PR DESCRIPTION
fixes bug #108, makes cmd_finder.rs not to follow symbolic link to test if python is installed.
Reason: std::path::PathBuf::exists cannot identify python installed from Microsoft App Store. This workaround makes the test passed.