### PR TITLE
Check vulkan sdk version

### DIFF
--- a/shaderc-sys/Cargo.toml
+++ b/shaderc-sys/Cargo.toml
@@ -22,3 +22,5 @@ libc = "0.2"
 
 [build-dependencies]
 cmake = "^0.1.37"
+roxmltree = "0.14.1"
+lenient_semver = { version = "0.4.2", features = [ "version_lite" ] }


### PR DESCRIPTION
A while back, I got a peculiarly cryptic error like this one: `Running rustc --crate-name vulkano_test [... very long arguments ...] undefined symbol: shaderc_compile_options_set_auto_combined_image_sampler`

It took me a while to figure out that this was a function in shaderc and that it was showing up just because the Vulkan SDK I had installed on my machine a while back was too old now. When I looked it up, I found several people with the same issue and with various solutions (often going back to an older version of shaderc-rs assuming it was a bug in it). It happened today again to someone.

This PR adds a check for the version of the vulkan SDK that shaderc-rs is trying to build from. I set the minimal version to 1.2.182.0 as it seems from my research that it is the version that introduced the missing function. **But I am not actually exactly sure if a version even more recent is needed or not.**