### PR TITLE
make Compiler Send and Sync

### DIFF
--- a/shaderc-rs/src/lib.rs
+++ b/shaderc-rs/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! let source = "#version 310 es\n void EP() {}";
 //!
-//! let mut compiler = shaderc::Compiler::new().unwrap();
+//! let compiler = shaderc::Compiler::new().unwrap();
 //! let mut options = shaderc::CompileOptions::new().unwrap();
 //! options.add_macro_definition("EP", Some("main"));
 //! let binary_result = compiler.compile_into_spirv(
@@ -407,6 +407,9 @@ pub struct Compiler {
     raw: *mut scs::ShadercCompiler,
 }
 
+unsafe impl Send for Compiler {}
+unsafe impl Sync for Compiler {}
+
 fn propagate_panic<F, T>(f: F) -> T
 where
     F: FnOnce() -> T,
@@ -505,7 +508,7 @@ impl Compiler {
     /// `entry_point_name` is a string defines the name of the entry point
     /// to associate with the source string.
     pub fn compile_into_spirv(
-        &mut self,
+        &self,
         source_text: &str,
         shader_kind: ShaderKind,
         input_file_name: &str,
@@ -541,7 +544,7 @@ impl Compiler {
     /// the [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools/blob/master/syntax.md)
     /// project.
     pub fn compile_into_spirv_assembly(
-        &mut self,
+        &self,
         source_text: &str,
         shader_kind: ShaderKind,
         input_file_name: &str,
@@ -573,7 +576,7 @@ impl Compiler {
     /// Like `compile_into_spirv` but the result contains preprocessed source
     /// code instead of a SPIR-V binary module.
     pub fn preprocess(
-        &mut self,
+        &self,
         source_text: &str,
         input_file_name: &str,
         entry_point_name: &str,
@@ -612,7 +615,7 @@ impl Compiler {
     /// For options specified in `additional_options`, the assembling will
     /// only pick those ones suitable for assembling.
     pub fn assemble(
-        &mut self,
+        &self,
         source_assembly: &str,
         additional_options: Option<&CompileOptions>,
     ) -> Result<CompilationArtifact> {
@@ -1341,7 +1344,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_vertex_shader_into_spirv() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result = c
             .compile_into_spirv(VOID_MAIN, ShaderKind::Vertex, "shader.glsl", "main", None)
             .unwrap();
@@ -1353,7 +1356,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_vertex_shader_into_spirv_assembly() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result = c
             .compile_into_spirv_assembly(VOID_MAIN, ShaderKind::Vertex, "shader.glsl", "main", None)
             .unwrap();
@@ -1362,7 +1365,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_preprocess() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.add_macro_definition("E", Some("main"));
         let result = c
@@ -1373,7 +1376,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_assemble() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result = c.assemble(VOID_MAIN_ASSEMBLY, None).unwrap();
         assert!(result.len() > 20);
         assert!(result.as_binary().first() == Some(&0x0723_0203));
@@ -1383,7 +1386,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_add_macro_definition_normal_value() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.add_macro_definition("E", Some("main"));
         let result = c
@@ -1400,7 +1403,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_add_macro_definition_empty_value() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.add_macro_definition("E", Some(""));
         let result = c
@@ -1417,7 +1420,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_add_macro_definition_no_value() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.add_macro_definition("E", None);
         let result = c
@@ -1434,7 +1437,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_clone() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.add_macro_definition("E", None);
         let o = options.clone().unwrap();
@@ -1452,7 +1455,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_source_language() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_source_language(SourceLanguage::HLSL);
         let result = c
@@ -1472,7 +1475,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_generate_debug_info() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_generate_debug_info();
         let result = c
@@ -1489,7 +1492,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_optimization_level_zero() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_optimization_level(OptimizationLevel::Zero);
         let result = c
@@ -1507,7 +1510,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_optimization_level_size() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_optimization_level(OptimizationLevel::Size);
         let result = c
@@ -1524,7 +1527,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_optimization_level_performance() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_optimization_level(OptimizationLevel::Performance);
         let result = c
@@ -1541,7 +1544,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_forced_version_profile_ok() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_forced_version_profile(450, GlslProfile::Core);
         let result = c
@@ -1561,7 +1564,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_forced_version_profile_err() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_forced_version_profile(310, GlslProfile::Es);
         let result = c.compile_into_spirv(
@@ -1580,7 +1583,7 @@ void main() { my_ssbo.x = 1.0; }";
     #[test]
     #[should_panic(expected = "Panic in include resolver!")]
     fn test_include_directive_panic() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_include_callback(|_, _, _, _| panic!("Panic in include resolver!"));
         drop(c.compile_into_spirv_assembly(
@@ -1597,7 +1600,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_include_directive_err() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_include_callback(|name, _, _, _| {
             Err(format!("Couldn't find header \"{}\"", name))
@@ -1620,7 +1623,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_include_directive_success() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_include_callback(|name, type_, _, _| {
             if name == "foo.glsl" && type_ == IncludeType::Relative {
@@ -1654,7 +1657,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_suppress_warnings() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_suppress_warnings();
         let result = c
@@ -1671,7 +1674,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_warnings_as_errors() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_warnings_as_errors();
         let result = c.compile_into_spirv(
@@ -1689,7 +1692,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_target_env_err_vulkan() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result = c.compile_into_spirv(
             COMPAT_FRAG,
             ShaderKind::Fragment,
@@ -1706,7 +1709,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_target_env_err_opengl() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_target_env(TargetEnv::OpenGL, 0);
         let result = c.compile_into_spirv(
@@ -1739,7 +1742,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_limit() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         assert!(c
             .compile_into_spirv(
@@ -1791,7 +1794,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_auto_bind_uniforms_false() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_auto_bind_uniforms(false);
         let result = c.compile_into_spirv_assembly(
@@ -1809,7 +1812,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_auto_bind_uniforms_true() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_auto_bind_uniforms(true);
         let result = c
@@ -1831,7 +1834,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_hlsl_offsets_false() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_hlsl_offsets(false);
         let result = c
@@ -1849,7 +1852,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_hlsl_offsets_true() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_hlsl_offsets(true);
         let result = c
@@ -1867,7 +1870,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_binding_base() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_auto_bind_uniforms(true);
         options.set_binding_base(ResourceKind::Image, 44);
@@ -1890,7 +1893,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_binding_base_for_stage_effective() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_auto_bind_uniforms(true);
         options.set_binding_base_for_stage(ShaderKind::Vertex, ResourceKind::Texture, 100);
@@ -1913,7 +1916,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_compile_options_set_binding_base_for_stage_ignore() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let mut options = CompileOptions::new().unwrap();
         options.set_auto_bind_uniforms(true);
         options.set_binding_base_for_stage(ShaderKind::Fragment, ResourceKind::Texture, 100);
@@ -1936,7 +1939,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_error_compilation_error() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result =
             c.compile_into_spirv(TWO_ERROR, ShaderKind::Vertex, "shader.glsl", "main", None);
         assert!(result.is_err());
@@ -1948,7 +1951,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_error_invalid_stage() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result = c.compile_into_spirv(
             VOID_MAIN,
             ShaderKind::InferFromSource,
@@ -1962,7 +1965,7 @@ void main() { my_ssbo.x = 1.0; }";
 
     #[test]
     fn test_warning() {
-        let mut c = Compiler::new().unwrap();
+        let c = Compiler::new().unwrap();
         let result = c
             .compile_into_spirv(ONE_WARNING, ShaderKind::Vertex, "shader.glsl", "main", None)
             .unwrap();


### PR DESCRIPTION
Fixes https://github.com/google/shaderc-rs/issues/113

I'm not 100% sure if this is safe. If not, this PR could be deleted.

It seems that the only reason `shaderc::Compiler` exists is to call `glslang::InitializeProcess` and `glslang::FinalizeProcess`, so it should be Send and Sync.