### PR TITLE
Derive `Debug` for `Compiler`

### DIFF
--- a/shaderc-rs/src/lib.rs
+++ b/shaderc-rs/src/lib.rs
@@ -403,6 +403,7 @@ pub enum Limit {
 ///
 /// Creating an `Compiler` object has substantial resource costs; so it is
 /// recommended to keep one object around for all tasks.
+#[derive(Debug)]
 pub struct Compiler {
     raw: *mut scs::ShadercCompiler,
 }


### PR DESCRIPTION
So client structs holding `Compiler` can derive `Debug`.