### PR TITLE
Don't try to build shaderc native library when building for docs.rs

### DIFF
--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -158,6 +158,14 @@ fn check_vulkan_sdk_version(path: &Path) -> Result<(), Box<dyn std::error::Error
 }
 
 fn main() {
+    // Don't attempt to build shaderc native library on docs.rs
+    if env::var("DOCS_RS").is_ok() {
+        println!(
+            "cargo:warning=shaderc: docs.rs detected, will not attempt to link against shaderc"
+        );
+        return;
+    }
+    
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
     let config_build_from_source = env::var("CARGO_FEATURE_BUILD_FROM_SOURCE").is_ok();


### PR DESCRIPTION
This fixes Windows cross-compile builds for crates that depend on `shaderc-rs`. 

example failed build: https://docs.rs/crate/librashader/0.1.0-beta.3/builds/721331

When the `DOCS_RS` environment variable is found don't even bother to build the native library since it is only needed for docs. It also saves time for Linux docs.rs builds that really have no need to link to the native library either. 
