### PR TITLE
Fix: Compilation issue causing incompatibility on Android via ADB or Termux

### DIFF
--- a/shaderc-sys/build/build.rs
+++ b/shaderc-sys/build/build.rs
@@ -357,7 +357,7 @@ fn main() {
             }
         } {
             match (target_os.as_str(), target_env.as_str()) {
-                ("linux", _) => {
+                ("linux" | "android", _) => {
                     println!("cargo:rustc-link-search=native={search_dir_str}");
                     println!("cargo:rustc-link-lib={lib_kind}={lib_name}");
                     return;


### PR DESCRIPTION
As the title says, this is a pretty minor patch to ensure the project can correctly get compiled on Android systems (Through a terminal emulator such as Termux or ADB).

It simply changes a check in the `build.rs` buildscript to check for either Linux or Android, instead of just Linux. So many ARM devices (Often with their own unique GPUs) use Android and don't support regular Linux distributions, so this is useful for testing on these systems. 